### PR TITLE
KZOO-524: Add ssl option parameters to support OTP 26+

### DIFF
--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -823,9 +823,13 @@ execute_request(ServiceContext = #service_context{}, ReqContext = #req_context{}
     %% Fiddler
     %% httpc:set_options([{ proxy, {{"localhost", 9999}, []}}]),
 
+
     Response = httpc:request(ReqContext#req_context.method,
                              erlazure_http:create_request(ReqContext, [AuthHeader | Headers1]),
-                             [{version, "HTTP/1.1"}, {ssl, [{versions, ['tlsv1.2']}]}],
+                             [{version, "HTTP/1.1"},
+                              {ssl, [{versions, ['tlsv1.2']},
+                                     {'verify', 'verify_peer'},
+                                     {'cacerts', public_key:cacerts_get()}]}], % recommended since OTP-25
                              [{sync, true}, {body_format, binary}, {headers_as_is, true}]),
     case Response of
         {ok, {{_, Code, _}, ResponseHeaders, Body}}


### PR DESCRIPTION
In order to support OTP 26+, the necessary parameters `verify` and  `cacerts` has been added.