### PR TITLE
KZOO-524: Added support for tls-1.3 and hostname verification

### DIFF
--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -827,8 +827,9 @@ execute_request(ServiceContext = #service_context{}, ReqContext = #req_context{}
     Response = httpc:request(ReqContext#req_context.method,
                              erlazure_http:create_request(ReqContext, [AuthHeader | Headers1]),
                              [{version, "HTTP/1.1"},
-                              {ssl, [{versions, ['tlsv1.2']},
+                              {ssl, [{versions, ['tlsv1.2', 'tlsv1.3']},
                                      {'verify', 'verify_peer'},
+                                     {customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]},
                                      {'cacerts', public_key:cacerts_get()}]}], % recommended since OTP-25
                              [{sync, true}, {body_format, binary}, {headers_as_is, true}]),
     case Response of


### PR DESCRIPTION
Previously the hostname verification process during SSL/TLS connections for wildcard certificates

Now, It allows more flexible hostname matching, including support for wildcard certificates.