### PR TITLE
KZOO-524: Added support for generating dynamic tls versions based on OpenSSL version

### DIFF
--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -827,7 +827,7 @@ execute_request(ServiceContext = #service_context{}, ReqContext = #req_context{}
     Response = httpc:request(ReqContext#req_context.method,
                              erlazure_http:create_request(ReqContext, [AuthHeader | Headers1]),
                              [{version, "HTTP/1.1"},
-                              {ssl, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                              {ssl, [{versions, proplists:get_value(supported, ssl:versions())},
                                      {'verify', 'verify_peer'},
                                      {customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]},
                                      {'cacerts', public_key:cacerts_get()}]}], % recommended since OTP-25


### PR DESCRIPTION
Previously, the erlazure library had static ssl options. 

Now, it will dynamically generate ssl versions.
